### PR TITLE
Make sure semicolon doesn't show up in lorem ipsum words

### DIFF
--- a/forgery_py/forgery/lorem_ipsum.py
+++ b/forgery_py/forgery/lorem_ipsum.py
@@ -46,7 +46,7 @@ def words(quantity=10, as_list=False):
     if not _words:
         _words = ' '.join(get_dictionary('lorem_ipsum')).lower().\
             replace('\n', '')
-        _words = re.sub(r'\.|,|;/', '', _words)
+        _words = re.sub(r'\.|,|;', '', _words)
         _words = _words.split(' ')
 
     result = random.sample(_words, quantity)

--- a/tests/test_lorem_ipsum.py
+++ b/tests/test_lorem_ipsum.py
@@ -5,6 +5,7 @@ import string
 from unittest import TestCase
 
 from forgery_py.forgery import lorem_ipsum
+from forgery_py.dictionaries_loader import get_dictionary
 
 
 class LoremIpsumForgeryTestCase(TestCase):
@@ -49,3 +50,12 @@ class LoremIpsumForgeryTestCase(TestCase):
         for paragraph in result:
             assert paragraph.startswith('<p>')
             assert paragraph.endswith('</p>')
+
+    def test_no_punctuation(self):
+        all_words = ' '.join(get_dictionary('lorem_ipsum')).lower().\
+                    replace('\n', '').split(' ')
+
+        result = lorem_ipsum.words(quantity=len(all_words))
+
+        for punctuation in ['.', ',', ';']:
+            assert punctuation not in result


### PR DESCRIPTION
Hello,

I use your package frequently in a test suite for an app I work on, and I love it! However, every once in a while, the `lorem_ipsum.word()` function will return this word: `'curae;'`, which messes stuff up for me because of the semicolon. From the `re.sub()` in that method it looks like you are trying to remove punctuation, but it appears that `';'` will only be removed if it is followed by `'/'`, which doesn't happen in your lorem ipsum text, so they are never removed. This PR addresses that. I added a test too. If I have missed something though, and this is the desired behavior, please disregard this PR. 

Thanks for the great tool!